### PR TITLE
Add Concat and Flatten helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ intent declaratively and produce elegant code that is easy to read and refactor.
 Please import our latest stable beta version:
 
 ```bash
-go get github.com/getkalido/fungi@v1.0.0-beta-4
+go get github.com/getkalido/fungi@latest
 ```
 
 ## Spread The Spores

--- a/concat.go
+++ b/concat.go
@@ -1,0 +1,42 @@
+package fungi
+
+import "io"
+
+// Concat joins together multiple streams of type T. For each input stream,
+// it will stream all elements of the input stream, before it begins
+// returning elements from the next input stream.
+//
+// Example
+//
+//	err := fungi.Loop(func(in int64) {
+//		fmt.Println(in)
+//	})(
+//		fungi.Concat(
+//			fungi.SliceStream([]int64{1, 2, 3}),
+//			fungi.SliceStream([]int64{4, 5}),
+//		),
+//	)
+func Concat[T any](streams ...Stream[T]) Stream[T] {
+	return &concat[T]{sources: streams}
+}
+
+type concat[T any] struct {
+	sources []Stream[T]
+}
+
+func (c *concat[T]) Next() (item T, err error) {
+	for len(c.sources) > 0 {
+		firstSource := c.sources[0]
+		item, err = firstSource.Next()
+		if err == nil {
+			return item, err
+		}
+		if err != io.EOF {
+			return
+		}
+		c.sources = c.sources[1:]
+	}
+
+	err = io.EOF
+	return
+}

--- a/concat_test.go
+++ b/concat_test.go
@@ -1,0 +1,28 @@
+package fungi_test
+
+import (
+	"fmt"
+
+	"github.com/getkalido/fungi"
+)
+
+func ExampleConcat() {
+	err := fungi.Loop(func(in int64) {
+		fmt.Println(in)
+	})(
+		fungi.Concat(
+			fungi.SliceStream([]int64{1, 2, 3}),
+			fungi.SliceStream([]int64{4, 5}),
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+}

--- a/filter.go
+++ b/filter.go
@@ -2,6 +2,9 @@ package fungi
 
 // Filter stream items using a custom checker function.
 func Filter[T any](ok func(T) bool) StreamIdentity[T] {
+	if ok == nil {
+		panic("ok function is nil in filter")
+	}
 	return func(items Stream[T]) Stream[T] {
 		return &filter[T]{
 			source: items,

--- a/flatten.go
+++ b/flatten.go
@@ -1,0 +1,39 @@
+package fungi
+
+// Flatten converts from a fungi.Stream[[]T] to a fungi.Stream[T]. It takes
+// a stream of slices of T and returns individual T elements in order.
+//
+// This does not handle deduplication of T, which can be performed with
+// [fungi.UniqueBy].
+//
+// Example:
+//
+//	someStream := fungi.SliceStream([][]int64{{1, 2, 3}, {4, 5}})
+//	slice, err := fungi.Loop(func (in int64) {
+//		fmt.Println(in)
+//	})(fungi.Flatten[int64](someStream))
+func Flatten[T comparable](source Stream[[]T]) Stream[T] {
+	return &flatten[T]{source: source}
+}
+
+type flatten[T any] struct {
+	source       Stream[[]T]
+	currentSlice []T
+}
+
+func (c *flatten[T]) Next() (item T, err error) {
+	if c.source == nil {
+		panic("nil source for flatmap")
+	}
+
+	for len(c.currentSlice) == 0 {
+		c.currentSlice, err = c.source.Next()
+		if err != nil {
+			return
+		}
+	}
+
+	item = c.currentSlice[0]
+	c.currentSlice = c.currentSlice[1:]
+	return
+}

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1,0 +1,24 @@
+package fungi_test
+
+import (
+	"fmt"
+
+	"github.com/getkalido/fungi"
+)
+
+func ExampleFlatten() {
+	someStream := fungi.SliceStream([][]int64{{1, 2, 3}, {4, 5}})
+	err := fungi.Loop(func(in int64) {
+		fmt.Println(in)
+	})(fungi.Flatten[int64](someStream))
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+}

--- a/for_each.go
+++ b/for_each.go
@@ -4,6 +4,8 @@ import "io"
 
 // ForEach uses the custom handler function given to it to process every item
 // from a stream.
+//
+// See [Loop] for a version which doesn't return errors.
 func ForEach[T any](handle func(T) error) StreamHandler[T] {
 	return func(items Stream[T]) (err error) {
 		var item T

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getkalido/fungi
 
 go 1.18
 
-require github.com/stretchr/testify v1.8.0
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,10 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/loop.go
+++ b/loop.go
@@ -1,7 +1,8 @@
 package fungi
 
-// Loop is similar to ForEach but it accepts a function that doesn't return any
-// error. It is simply a convenient alias for you to use.
+// Loop calls an infallible function on each element of the input stream.
+//
+// See [ForEach] for a version which can return errors.
 func Loop[T any](handle func(T)) StreamHandler[T] {
 	return ForEach(func(item T) error { handle(item); return nil })
 }


### PR DESCRIPTION
- Adds the `Concat` stream, to join the output of multiple streams in sequence.
- Adds the `Flatten` stream, which takes a stream of `[]T` and converts it to a stream of `T`.
- Fixes some unhelpful documentation.
- Updates imported packages.
- Refactors `UniqueBy` to reduce memory consumption.