### PR TITLE
Add Chunk transformer to chunk streams into streams of slices.

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,67 @@
+package fungi
+
+import "io"
+
+// Chunk converts from a fungi.Stream[T] to a fungi.Stream[[]T]. It takes
+// a stream of T and returns chunked slices of T in order.
+//
+// Example:
+//
+//	someStream := fungi.SliceStream([]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+//	err := fungi.Loop(func(in []int64) {
+//		fmt.Println(in)
+//	})(fungi.Chunk[int64](3)(someStream))
+func Chunk[T any](chunkSize int) StreamTransformer[T, []T] {
+	if chunkSize <= 0 {
+		panic("chunk size must be greater than 0")
+	}
+	return func(source Stream[T]) Stream[[]T] {
+		return &chunk[T]{
+			source:       source,
+			chunkSize:    chunkSize,
+			currentSlice: make([]T, 0, chunkSize),
+		}
+	}
+}
+
+type chunk[T any] struct {
+	source       Stream[T]
+	chunkSize    int
+	currentSlice []T
+	err          error
+}
+
+func (c *chunk[T]) Next() (items []T, err error) {
+	if c.source == nil {
+		panic("nil source for chunking")
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	for len(c.currentSlice) < c.chunkSize {
+		item, err := c.source.Next()
+		if err == nil {
+			c.currentSlice = append(c.currentSlice, item)
+			continue
+		}
+		c.err = err
+		if err != io.EOF {
+			return nil, err
+		}
+		if len(c.currentSlice) == 0 {
+			return nil, io.EOF
+		}
+		break
+	}
+
+	var chunkLen int
+	if len(c.currentSlice) < c.chunkSize {
+		chunkLen = len(c.currentSlice)
+	} else {
+		chunkLen = c.chunkSize
+	}
+	items = c.currentSlice[:chunkLen]
+	c.currentSlice = c.currentSlice[chunkLen:]
+	return items, nil
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,228 @@
+package fungi_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/getkalido/fungi"
+)
+
+func ExampleChunk() {
+	someStream := fungi.SliceStream([]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	err := fungi.Loop(func(in []int64) {
+		fmt.Println(in)
+	})(fungi.Chunk[int64](3)(someStream))
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// [1 2 3]
+	// [4 5 6]
+	// [7 8 9]
+	// [10]
+}
+
+func ExampleChunk_ChunkAndReflatten() {
+	someStream := fungi.SliceStream([]int64{1, 2, 3, 4, 5})
+
+	err := fungi.Loop(func(in int32) {
+		fmt.Println(in)
+	})(
+		fungi.Flatten[int32](
+			fungi.Map[[]int64, []int32](
+				func(in []int64) []int32 {
+					// This transformer is just for demonstration purposes,
+					// but can be replaced with, for example, API calls
+					fmt.Println(in)
+					result := make([]int32, 0, len(in))
+					for _, v := range in {
+						result = append(result, int32(v))
+					}
+					return result
+				})(
+				fungi.Chunk[int64](3)(
+					someStream,
+				),
+			),
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// [1 2 3]
+	// 1
+	// 2
+	// 3
+	// [4 5]
+	// 4
+	// 5
+}
+
+func TestChunkZero(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic for chunk size 0, but did not panic")
+		}
+	}()
+	fungi.Chunk[int64](0)
+}
+
+type SequentialStream struct {
+	MaxCounter int64
+	FailFunc   func(int64) (int64, error)
+	counter    int64
+}
+
+func (s *SequentialStream) Next() (int64, error) {
+	if s.MaxCounter <= 0 {
+		s.MaxCounter = 10
+	}
+	if s.counter < s.MaxCounter {
+		s.counter++
+		return s.counter, nil
+	}
+	if s.FailFunc == nil {
+		return 0, io.EOF
+	}
+	return s.FailFunc(s.counter)
+}
+
+func SliceEqual(a []int64, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestChunkLengthSubdividesExactly(t *testing.T) {
+	stream := &SequentialStream{
+		MaxCounter: 9,
+	}
+	chunker := fungi.Chunk[int64](3)(stream)
+
+	var (
+		chunk []int64
+		err   error
+	)
+	for i, expectedChunk := range [][]int64{
+		{1, 2, 3},
+		{4, 5, 6},
+		{7, 8, 9},
+	} {
+		chunk, err := chunker.Next()
+		if err != nil {
+			t.Fatalf("Expected no error on chunk %d, got: %v", i+1, err)
+		}
+		if !SliceEqual(chunk, expectedChunk) {
+			t.Fatalf("Expected chunk %d to be %v, got: %v", i+1, expectedChunk, chunk)
+		}
+	}
+
+	chunk, err = chunker.Next()
+	if len(chunk) > 0 {
+		t.Fatalf("Expected exhausted chunk to be empty, got: %v", chunk)
+	}
+	if err != io.EOF {
+		t.Fatalf("Expected io.EOF on fourth chunk, but got %v", err)
+	}
+}
+
+func TestChunkError(t *testing.T) {
+	stream := &SequentialStream{
+		MaxCounter: 10,
+		FailFunc: func(counter int64) (int64, error) {
+			return 0, fmt.Errorf("error at counter %d", counter)
+		},
+	}
+	chunker := fungi.Chunk[int64](3)(stream)
+
+	var (
+		chunk []int64
+		err   error
+	)
+	for i, expectedChunk := range [][]int64{
+		{1, 2, 3},
+		{4, 5, 6},
+		{7, 8, 9},
+	} {
+		chunk, err := chunker.Next()
+		if err != nil {
+			t.Fatalf("Expected no error on chunk %d, got: %v", i+1, err)
+		}
+		if !SliceEqual(chunk, expectedChunk) {
+			t.Fatalf("Expected chunk %d to be %v, got: %v", i+1, expectedChunk, chunk)
+		}
+	}
+
+	chunk, err = chunker.Next()
+	if len(chunk) > 0 {
+		t.Fatalf("Expected errored chunk to be empty, got: %v", chunk)
+	}
+	if err == nil {
+		t.Fatal("Expected error on fourth chunk, but got nil")
+	}
+
+	chunk, finalErr := chunker.Next()
+	if len(chunk) > 0 {
+		t.Fatalf("Expected errored chunk to be empty, got: %v", chunk)
+	}
+	if err == nil {
+		t.Fatal("Expected error on chunk after error, but got nil")
+	}
+	errors.Is(finalErr, err)
+	if err == nil {
+		t.Fatalf("To receive error again, but got %v", finalErr)
+	}
+}
+
+func TestChunkPullAfterExhaustion(t *testing.T) {
+	stream := &SequentialStream{
+		MaxCounter: 10,
+	}
+	chunker := fungi.Chunk[int64](3)(stream)
+
+	var (
+		chunk []int64
+		err   error
+	)
+	for i, expectedChunk := range [][]int64{
+		{1, 2, 3},
+		{4, 5, 6},
+		{7, 8, 9},
+		{10},
+	} {
+		chunk, err := chunker.Next()
+		if err != nil {
+			t.Fatalf("Expected no error on chunk %d, got: %v", i+1, err)
+		}
+		if !SliceEqual(chunk, expectedChunk) {
+			t.Fatalf("Expected chunk %d to be %v, got: %v", i+1, expectedChunk, chunk)
+		}
+	}
+
+	chunk, err = chunker.Next()
+	if len(chunk) > 0 {
+		t.Fatalf("Expected exhausted chunk to be empty, got: %v", chunk)
+	}
+	if err != io.EOF {
+		t.Fatalf("Expected io.EOF on fourth chunk, but got %v", err)
+	}
+
+	chunk, err = chunker.Next()
+	if len(chunk) > 0 {
+		t.Fatalf("Expected exhausted chunk to be empty again, got: %v", chunk)
+	}
+	if err != io.EOF {
+		t.Fatalf("Expected io.EOF on fifth chunk, but got %v", err)
+	}
+}

--- a/flatten.go
+++ b/flatten.go
@@ -12,7 +12,7 @@ package fungi
 //	slice, err := fungi.Loop(func (in int64) {
 //		fmt.Println(in)
 //	})(fungi.Flatten[int64](someStream))
-func Flatten[T comparable](source Stream[[]T]) Stream[T] {
+func Flatten[T any](source Stream[[]T]) Stream[T] {
 	return &flatten[T]{source: source}
 }
 


### PR DESCRIPTION
It has become necessary to chunk streams into slices of streams, so that we can break up bulk API calls into chunks.